### PR TITLE
Replace long() with int()

### DIFF
--- a/pkcs1/primitives.py
+++ b/pkcs1/primitives.py
@@ -23,7 +23,7 @@ from . import exceptions
 def _pow(a, b, mod):
     '''Exponentiation function using acceleration from gmpy if possible'''
     if gmpy:
-        return long(pow(gmpy.mpz(a), gmpy.mpz(b), gmpy.mpz(mod)))
+        return int(pow(gmpy.mpz(a), gmpy.mpz(b), gmpy.mpz(mod)))
     else:
         return pow(a, b, mod)
 


### PR DESCRIPTION
Long() is no longer supported in Python 3.x and should be replaced with int() as it supports arbitrarily large integers.